### PR TITLE
fix typo

### DIFF
--- a/infrastructure/docker/docker.md
+++ b/infrastructure/docker/docker.md
@@ -64,7 +64,7 @@ COMMAND | DESCRIPTION
 COMMAND | DESCRIPTION
 ---|---
 `docker ps` | List running containers
-`docker ps -a` | List all running containers
+`docker ps -a` | List all containers, including stopped
 `docker logs CONTAINER` | Show a container output
 `docker logs -f CONTAINER` | Follow a container output
 `docker top CONTAINER` | List the processes running in a container


### PR DESCRIPTION
docker ps Lists running containers, docker ps -a Lists _all_ containers, including stopped (previously: lists all running containers: probably correct, but ambiguous)