### PR TITLE
Added Application and ApplicationSet examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .obsidian
+.vscode

--- a/apps/argocd.md
+++ b/apps/argocd.md
@@ -81,3 +81,67 @@ stringData:
 3. Verify new repository is connected
 
 ---
+
+### Declarative Application and ApplicationSet
+
+Apart from using the WebUI to add managed apps to ArgoCD, you can configure `Application`
+and `ApplicationSet` resources. This enables you to define not only ArgoCD and your apps
+as code, but also the definition which application you want to manage.
+With apps defined as YAML via an `Application`, you can e.g. deploy the app within a CI/CD
+pipeline that deploys your Argo instance.
+
+There are two types of resources. `Application` and `ApplicationSet`. The main difference is,
+that you can specify so called inline generators which allow you to template your Application
+definition. If you manage multiple clusters with ArgoCD and you want to get an `Application`
+deployed with cluster specific parameters you want to use an `ApplicationSet`.
+
+Below, you find an example for an `Application` and an `ApplicationSet`.
+
+**Application:**
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: guestbook
+  namespace: argocd
+spec:
+  destination:
+    namespace: default
+    server: 'https://kubernetes.default.svc'
+  source:
+    path: kustomize-guestbook
+    repoURL: 'https://github.com/argoproj/argocd-example-apps'
+    targetRevision: HEAD
+  project: default
+  syncPolicy:
+    automated:
+      prune: false
+      selfHeal: false
+```
+
+**ApplicationSet:**
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: guestbook
+  namespace: argocd
+spec:
+  generators:
+  - clusters: {} # This is a generator, specifically, a cluster generator.
+  template: 
+    # This is a template Argo CD Application, but with support for parameter substitution.
+    metadata:
+      name: '{{name}}-guestbook'
+    spec:
+      project: "default"
+      source:
+        repoURL: https://github.com/argoproj/argocd-example-apps/
+        targetRevision: HEAD
+        path: kustomize-guestbook
+      destination:
+        server: '{{server}}'
+        namespace: default
+```


### PR DESCRIPTION
Hello,

I've added some examples for `Application` and `ApplicationSet` CRDs. Using these resource types allows you to also manage Application definitions as code instead of using the WebUI to create an Application to manage.

More information on this topic can be found [here](https://thedatabaseme.de/2022/06/05/let-loose-the-squid-deploy-argocd-the-declarative-way/).

Looking forward for feedback.

Kind regards
Philip