### PR TITLE
Correct typos in misc/markdown.md

### DIFF
--- a/misc/markdown.md
+++ b/misc/markdown.md
@@ -105,7 +105,7 @@ The outer pipes (|) are optional, and you don't need to make the raw Markdown li
 
 ### Task list
 
-To create a taksk lsit start line with square brackets with an empty space.
+To create a task list start line with square brackets with an empty space.
 Ex: [ <space> ] and add text for task.
 To check the task replace the space between the bracket with "x".
 


### PR DESCRIPTION
Noticed two typos in the task list section that I took the liberty to correct. 

What a great resource, thank you for creating! 