### PR TITLE
fix: fix formatting issue with pipe character in table

### DIFF
--- a/tools/vagrant.md
+++ b/tools/vagrant.md
@@ -24,7 +24,7 @@ COMMAND | DESCRIPTION
 ---|---
 `vagrant provision` |  Forces reprovisioning of the vagrant machine
 `vagrant provision --debug ` | Use the debug flag to increase the verbosity of the output
-`vagrant up --provision | tee provision.log` | Runs `vagrant up`, forces provisioning and logs all output to a file
+`vagrant up --provision \| tee provision.log` | Runs `vagrant up`, forces provisioning and logs all output to a file
 
 ## Manage Boxes
 COMMAND | DESCRIPTION


### PR DESCRIPTION
Avoid the pipe character in code to be misinterpreted as column separator of the Markdown table.