### PR TITLE
Added macOS and iOS instructions to ssl-certs

### DIFF
--- a/misc/ssl-certs.md
+++ b/misc/ssl-certs.md
@@ -128,3 +128,15 @@ The exact steps vary device-to-device, but here is a generalised guide:
 5. Locate the certificate file `ca.pem` on your SD Card/Internal Storage using the file manager.
 6. Select to load it.
 7. Done!
+
+## On iOS
+
+Apple makes this far more difficult than it should be:
+1. Send `ca.pem` to the iOS device through iCloud, AirDrop, or a direct download from your server.
+2. After downloading a dialog will appear on screen telling you that the profile has been downloaded.
+3. Open the Settings app, and a `Profile Downloaded` item will be at the top. If it is not there you may find it in `General → VPN & Device Management`.
+4. Click `Install`.
+5. The device will ask for your passcode. Enter it.
+6. The device will then warn you about the certificate. Click `Install` again.
+7. And, as if clicking `Install` twice wasn't enough a confirmation button will appear at the bottom of the screen. Click `Install` one last time.
+7. Done!

--- a/misc/ssl-certs.md
+++ b/misc/ssl-certs.md
@@ -92,6 +92,15 @@ update-ca-trust
 ```
 wiki page  [here](https://wiki.archlinux.org/title/User:Grawity/Adding_a_trusted_CA_certificate)
 
+### On macOS
+
+Assuming the path to your generated CA certificate is `~/ca.pem`, run (as root):
+```bash
+security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain ~/ca.pem
+```
+
+A dialog box will appear asking for an administrator's username and password. Enter it, and it will be stored in the system keychain. This can be verified by opening the `Keychain Access` application (`/Applications/Utilities/Keychain Access.app`). On the sidebar under `System Keychains` select `System`, and the new certificate should be listed.
+
 ### On Windows
 
 Assuming the path to your generated CA certificate as `C:\ca.pem`, run:


### PR DESCRIPTION
After following your excellent instructions on self-signing certificates I needed to add them to a Mac and an iPhone, so here's a pull request adding instructions so others may benefit.